### PR TITLE
Fixed going back after opening intents

### DIFF
--- a/app/src/main/java/com/smartpack/packagemanager/fragments/PackageInfoFragment.java
+++ b/app/src/main/java/com/smartpack/packagemanager/fragments/PackageInfoFragment.java
@@ -107,7 +107,6 @@ public class PackageInfoFragment extends Fragment {
                 Intent launchIntent = requireActivity().getPackageManager().getLaunchIntentForPackage(Common.getApplicationID());
                 if (launchIntent != null) {
                     startActivity(launchIntent);
-                    requireActivity().finish();
                 } else {
                     Utils.snackbar(mRootView, getString(R.string.open_failed, Common.getApplicationName()));
                 }
@@ -200,7 +199,6 @@ public class PackageInfoFragment extends Fragment {
             Uri uri = Uri.fromParts("package", Common.getApplicationID(), null);
             settings.setData(uri);
             startActivity(settings);
-            requireActivity().finish();
         });
         if (Utils.rootAccess()) {
             mClear.setVisibility(View.VISIBLE);


### PR DESCRIPTION
Hi,

I've found that opening an app or information from package info and going back, returns the user to the main page of the app. For me, it was a bit irritating, especially when I tapped any of the buttons by accidents or just wanted to check the app before uninstalling it. I've fixed that. Other buttons on the same view were working correctly, so I haven't changed them (uninstall also has the same behavior, but it's correct here).

**Before:**

https://user-images.githubusercontent.com/85929121/134797792-0b427f23-1f10-470a-b748-fe9cf2d1bdf9.mp4

**After:**

https://user-images.githubusercontent.com/85929121/134797803-dc969826-f6d3-4fc2-b6e4-73d22e44b9dc.mp4

